### PR TITLE
Allow .m3u8 as a file format

### DIFF
--- a/javascripts/discourse/controllers/insert-video.js.es6
+++ b/javascripts/discourse/controllers/insert-video.js.es6
@@ -49,7 +49,7 @@ export default Controller.extend(ModalFunctionality, {
     if (sources) {
       const srcArray = sources.split("|");
 
-      if (!srcArray.every(isVideo)) {
+      if (!srcArray.every((url) => { return isVideo(url) || url.endsWith(".m3u8") })) {
         this.set("validationMessage", I18n.t(themePrefix("source_not_video")));
         return false;
       }


### PR DESCRIPTION
Allows [m3u8](https://en.wikipedia.org/wiki/M3U) URLs to be added manually without error.