### PR TITLE
FIX: set the correct mime type for accepting mov files

### DIFF
--- a/javascripts/discourse/templates/components/video-uploader.hbs
+++ b/javascripts/discourse/templates/components/video-uploader.hbs
@@ -4,7 +4,7 @@
     class="hidden-upload-field"
     disabled={{addDisabled}}
     type="file"
-    accept="video/mp4,video/webm,video/mov"
+    accept="video/mp4,video/webm,video/quicktime"
   />
 </label>
 {{conditional-loading-spinner condition=addDisabled}}


### PR DESCRIPTION
Fix the `mov` mimetype from `mov` to `QuickTime` so the input let us select `.mov` files.