### PR TITLE
DEV: inject appEvents into modal component

### DIFF
--- a/javascripts/discourse/components/modal/insert-video.js
+++ b/javascripts/discourse/components/modal/insert-video.js
@@ -2,10 +2,13 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { empty } from "@ember/object/computed";
+import { inject as service } from "@ember/service";
 import { isVideo } from "discourse/lib/uploads";
 import I18n from "I18n";
 
 export default class InsertVideoModal extends Component {
+  @service appEvents;
+
   @tracked sources;
   @tracked tracks;
   @tracked poster;

--- a/javascripts/discourse/components/modal/insert-video.js
+++ b/javascripts/discourse/components/modal/insert-video.js
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { empty } from "@ember/object/computed";
-import { inject as service } from "@ember/service";
+import { service } from "@ember/service";
 import { isVideo } from "discourse/lib/uploads";
 import I18n from "I18n";
 

--- a/spec/system/insert_video_spec.rb
+++ b/spec/system/insert_video_spec.rb
@@ -17,11 +17,17 @@ RSpec.describe "Inserting Video from Composer", system: true do
   it "should upload video" do
     SiteSetting.authorized_extensions += "|mp4|vtt"
     video_file =
-      File.absolute_path(Pathname.new("#{__FILE__}/../../fixtures/media/sample_video.mp4"))
+      File.absolute_path(
+        Pathname.new("#{__FILE__}/../../fixtures/media/sample_video.mp4")
+      )
     poster_file =
-      File.absolute_path(Pathname.new("#{__FILE__}/../../fixtures/images/poster_small.jpg"))
+      File.absolute_path(
+        Pathname.new("#{__FILE__}/../../fixtures/images/poster_small.jpg")
+      )
     subtitle_file =
-      File.absolute_path(Pathname.new("#{__FILE__}/../../fixtures/media/sample_video.vtt"))
+      File.absolute_path(
+        Pathname.new("#{__FILE__}/../../fixtures/media/sample_video.vtt")
+      )
 
     visit "/new-topic"
     expect(composer).to be_opened
@@ -45,6 +51,7 @@ RSpec.describe "Inserting Video from Composer", system: true do
     expect(insert_video_modal.video_source_input_field[:title]).to include "mp4"
     expect(insert_video_modal.poster_input_field.value).to include ".jpeg"
     insert_video_modal.click_insert_video_button
+    expect(insert_video_modal).to be_closed
 
     video_preview = composer.preview.find("video[controls][poster]")
     expect(video_preview).to be_visible


### PR DESCRIPTION
Somehow in this previous commit I removed the import needed to make it work - https://github.com/discourse/discourse-insert-video/commit/6dea57fa40809f1a3f120e526f100916fdd6a403

And the system spec didn't fail b/c the system spec didn't check that the modal closed after inserting the video. Updating spec to make sure the modal closes (nothing errors) as well as injecting `appEvents` into modal.