### PR TITLE
DEV: don't rely on stripped data-test-id in system spec

### DIFF
--- a/javascripts/discourse/components/modal/insert-video.gjs
+++ b/javascripts/discourse/components/modal/insert-video.gjs
@@ -159,7 +159,6 @@ export default class InsertVideoModal extends Component {
       <:footer>
         <DButton
           class="btn-primary"
-          data-test-id="insert-video-button"
           @disabled={{this.insertDisabled}}
           @label={{themePrefix "modal.insert"}}
           @action={{this.insertVideo}}

--- a/spec/system/page_objects/modals/insert_video.rb
+++ b/spec/system/page_objects/modals/insert_video.rb
@@ -30,7 +30,10 @@ module PageObjects
       end
 
       def click_insert_video_button
-        footer.find('[data-test-id="insert-video-button"]').click
+        # NOTE: `data-test-*` attributes are stripped from minified theme builds
+        # (which is what system specs run against), so we cannot rely on them
+        # here. The insert button is the only `.btn-primary` in the footer.
+        footer.find(".btn-primary").click
       end
     end
   end


### PR DESCRIPTION
Discourse 2026.6.0 runs the strip-test-selectors plugin during minified theme builds, which removes all data-test-* attributes from compiled templates. System specs run against the minified build, so the insert button's data-test-id never reached the DOM and the Capybara lookup failed with ElementNotFound.

Select the insert button by its .btn-primary class instead (the only primary button in the modal footer), and drop the now-dead data-test-id from the component.